### PR TITLE
Use Client to keep fields cache to avoid mixing from different connections

### DIFF
--- a/gisce/base.py
+++ b/gisce/base.py
@@ -19,6 +19,9 @@ def to_camel_case(model):
 
 
 class Client(requests.Session):
+    
+    _cache_fields = {}
+    
     def __init__(self, url=None, token=None, user=None, password=None):
         super(Client, self).__init__()
         self.headers.update({
@@ -57,11 +60,11 @@ class Model(object):
 
     @property
     def cache_fields(self):
-        return self.__class__._fields.get(self._name, {})
+        return self.api.__class__._cache_fields.get(self._name, {})
 
     @cache_fields.setter
     def cache_fields(self, value):
-        self.__class__._fields[self._name] = value
+        self.api.__class__._cache_fields[self._name] = value
 
     def __getattr__(self, item):
         def wrapper(*args, **kwargs):


### PR DESCRIPTION
If we connect to to one server, and then another server, the cache of the fields is maintained across the different connections. Moving this cache to client fixes this.