### PR TITLE
Add unified connect method

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,16 @@ database = 'test'
 c = Client(url, database=database, user=user, password=password)
 users_obj = c.model('res.users')
 ```
+
+## Using a single method
+```python
+from gisce import connect
+url = 'http+xmlrpc://localhost:8069'
+c = connect(url,'test', user='admin', password='agmin')
+users_obj = c.model('res.users')
+```
+
+Where allowed protocols are:
+ - http[s]+restpai
+ - http[s]+msgpack
+ - http[s]+xmlrpc

--- a/gisce/__init__.py
+++ b/gisce/__init__.py
@@ -17,3 +17,18 @@ else:
 from .restapi import RestApiClient
 from .msgpack import MsgPackClient
 from .xmlrpc import XmlRpcClient
+
+PROTOCOL_MAP = {
+    'restapi': RestApiClient,
+    'msgpack': MsgPackClient,
+    'xmlrpc': XmlRpcClient,
+}
+
+
+def connect(url, *args, **kwargs):
+    import re
+    for protocol, client in PROTOCOL_MAP.items():
+        pattern = re.compile(r'http[s]?\+{}://*'.format(protocol))
+        if pattern.match(url):
+            url = re.sub(r'\+{}'.format(protocol), '', url)
+            return client(url, *args, **kwargs)


### PR DESCRIPTION
## Using a single method
```python
from gisce import connect
url = 'http+xmlrpc://localhost:8069'
c = connect(url,'test', user='admin', password='agmin')
users_obj = c.model('res.users')
```

Where allowed protocols are:
 - http[s]+restpai
 - http[s]+msgpack
 - http[s]+xmlrpc