### PR TITLE
Add client property mapped to api

### DIFF
--- a/gisce/base.py
+++ b/gisce/base.py
@@ -76,6 +76,10 @@ class Model(object):
             self.cache_fields = self.fields_get()
 
     @property
+    def client(self):
+        return self.api
+
+    @property
     def camelcase(self):
         return to_camel_case(self._name)
 


### PR DESCRIPTION
Map a `client` property to api varible to keep [api comaptible with erppeek](https://github.com/tinyerp/erppeek/blob/9a43eb9a07919db90ed8b8f2350f96a45bc63df1/erppeek.py#L1128)

