### PR TITLE
Fix Infinite recursion call for RestApi Models

### DIFF
--- a/gisce/base.py
+++ b/gisce/base.py
@@ -51,6 +51,8 @@ class RequestsClient(requests.Session, BaseClient):
     
     def __init__(self, url=None, token=None, user=None, password=None):
         super(RequestsClient, self).__init__()
+        BaseClient.__init__(self)
+
         self.headers.update({
             'User-Agent': '{}/{}'.format(USER_AGENT, VERSION)
         })


### PR DESCRIPTION
- Call BaseClient `__init__` on RequestsClient `__init__`  (models attribute was never set cause `BaseClient.__init__` not called)