### PR TITLE
Allow disabling SSL certificate verification in RequestsClient and MsgPackClient for self-signed certificates

### DIFF
--- a/gisce/base.py
+++ b/gisce/base.py
@@ -49,9 +49,19 @@ class BaseClient(object):
 
 class RequestsClient(requests.Session, BaseClient):
     
-    def __init__(self, url=None, token=None, user=None, password=None):
+    def __init__(self, url=None, token=None, user=None, password=None, verify=None):
+        """
+        :param url:
+        :param token:
+        :param user:
+        :param password:
+        :param verify: If we are using self signed certificate we can skip validation using verify=False
+        To keep request default verify=None (by default if verify is None  it verifies)
+        """
         super(RequestsClient, self).__init__()
         BaseClient.__init__(self)
+
+        self.verify = verify
 
         self.headers.update({
             'User-Agent': '{}/{}'.format(USER_AGENT, VERSION)
@@ -69,7 +79,7 @@ class RequestsClient(requests.Session, BaseClient):
 
     def request(self, method, url, *args, **kwargs):
         url = '/'.join([self.url, url])
-        return super(RequestsClient, self).request(method, url, *args, **kwargs)
+        return super(RequestsClient, self).request(method, url, *args, verify=self.verify, **kwargs)
 
 
 class Model(object):

--- a/gisce/compat.py
+++ b/gisce/compat.py
@@ -2,6 +2,6 @@ import sys
 PY2 = sys.version_info < (3, 0, 0)
 
 if PY2:
-    from xmlrpclib import ServerProxy
+    from xmlrpclib import ServerProxy, SafeTransport
 else:
-    from xmlrpc.client import ServerProxy
+    from xmlrpc.client import ServerProxy, SafeTransport

--- a/gisce/msgpack.py
+++ b/gisce/msgpack.py
@@ -58,8 +58,8 @@ class MsgPackClient(RequestsClient):
     model_class = MsgPackModel
 
     def __init__(self, url, database, token=None, user=None, password=None,
-                 content_type='json'):
-        super(MsgPackClient, self).__init__(url, token, user, password)
+                 content_type='json', verify=None):
+        super(MsgPackClient, self).__init__(url, token, user, password, verify)
         self.database = database
         assert content_type in ('json', 'msgpack')
         if content_type == 'msgpack' and not MSGPACK_AVAILABLE:

--- a/gisce/xmlprc_wst.py
+++ b/gisce/xmlprc_wst.py
@@ -20,12 +20,12 @@ class XmlRpcWstModel(XmlRpcModel):
 class XmlRpcClientWst(XmlRpcClient):
     model_class = XmlRpcWstModel
 
-    def __init__(self, url, database, token=None, user=None, password=None):
+    def __init__(self, url, database, token=None, user=None, password=None, verify=None):
         super(XmlRpcClientWst, self).__init__(
-            url, database, token, user, password
+            url, database, token, user, password, verify
         )
         self.tid = None
-        self.sync = ServerProxy(self.url + '/ws_transaction', allow_none=True)
+        self.sync = ServerProxy(self.url + '/ws_transaction', allow_none=True, **self.server_proxy_kwargs)
 
     @property
     def wst(self):


### PR DESCRIPTION
Adds an optional verify parameter to the constructors of RequestsClient, MsgPackClient, XmlRpcClient and XmlRpcClientWst.

By default, if verify is None, it behaves exactly as before—delegating to the default requests behavior, which performs certificate verification. However, you can now pass verify=False to skip SSL certificate verification, which is particularly useful when working with self-signed certificates in development or testing environments.