### PR TITLE
Add password prompting

### DIFF
--- a/gisce/base.py
+++ b/gisce/base.py
@@ -49,7 +49,8 @@ class BaseClient(object):
 
 class RequestsClient(requests.Session, BaseClient):
     
-    def __init__(self, url=None, token=None, user=None, password=None, verify=None):
+    def __init__(self, url=None, token=None, user=None, password=None, verify=None,
+                 prompt_for_password=False):
         """
         :param url:
         :param token:
@@ -57,6 +58,8 @@ class RequestsClient(requests.Session, BaseClient):
         :param password:
         :param verify: If we are using self signed certificate we can skip validation using verify=False
         To keep request default verify=None (by default if verify is None  it verifies)
+        :param prompt_for_password: If True and user is provided without a password, prompt interactively.
+        If False (default) and user is provided without a password, raises ValueError.
         """
         super(RequestsClient, self).__init__()
         BaseClient.__init__(self)
@@ -69,8 +72,14 @@ class RequestsClient(requests.Session, BaseClient):
         if user and password:
             self.auth = (user, password)
         elif user and not password and not token:
-            from .compat import getpass
-            password = getpass('base Password: ')
+            if prompt_for_password:
+                from .compat import prompt_password
+                password = prompt_password()
+            else:
+                raise ValueError(
+                    "Password required for user '{}' but none provided. "
+                    "Use prompt_for_password=True for interactive prompting.".format(user)
+                )
             self.auth = (user, password)
         elif token:
             self.headers.update({

--- a/gisce/base.py
+++ b/gisce/base.py
@@ -68,6 +68,10 @@ class RequestsClient(requests.Session, BaseClient):
         })
         if user and password:
             self.auth = (user, password)
+        elif user and not password and not token:
+            from .compat import getpass
+            password = getpass('base Password: ')
+            self.auth = (user, password)
         elif token:
             self.headers.update({
                 'Authorization': 'token {}'.format(token)

--- a/gisce/base.py
+++ b/gisce/base.py
@@ -70,14 +70,8 @@ class RequestsClient(requests.Session, BaseClient):
         if user and password:
             self.auth = (user, password)
         elif user and not password and not token:
-            from .compat import is_interactive, prompt_password
-            if is_interactive():
-                password = prompt_password()
-            else:
-                raise ValueError(
-                    "Password required for user '{}' but none provided.".format(user)
-                )
-            self.auth = (user, password)
+            from .compat import get_password
+            self.auth = (user, get_password(user, password))
         elif token:
             self.headers.update({
                 'Authorization': 'token {}'.format(token)

--- a/gisce/base.py
+++ b/gisce/base.py
@@ -49,8 +49,7 @@ class BaseClient(object):
 
 class RequestsClient(requests.Session, BaseClient):
     
-    def __init__(self, url=None, token=None, user=None, password=None, verify=None,
-                 prompt_for_password=False):
+    def __init__(self, url=None, token=None, user=None, password=None, verify=None):
         """
         :param url:
         :param token:
@@ -58,8 +57,6 @@ class RequestsClient(requests.Session, BaseClient):
         :param password:
         :param verify: If we are using self signed certificate we can skip validation using verify=False
         To keep request default verify=None (by default if verify is None  it verifies)
-        :param prompt_for_password: If True and user is provided without a password, prompt interactively.
-        If False (default) and user is provided without a password, raises ValueError.
         """
         super(RequestsClient, self).__init__()
         BaseClient.__init__(self)
@@ -72,13 +69,12 @@ class RequestsClient(requests.Session, BaseClient):
         if user and password:
             self.auth = (user, password)
         elif user and not password and not token:
-            if prompt_for_password:
-                from .compat import prompt_password
+            from .compat import is_interactive, prompt_password
+            if is_interactive():
                 password = prompt_password()
             else:
                 raise ValueError(
-                    "Password required for user '{}' but none provided. "
-                    "Use prompt_for_password=True for interactive prompting.".format(user)
+                    "Password required for user '{}' but none provided.".format(user)
                 )
             self.auth = (user, password)
         elif token:

--- a/gisce/compat.py
+++ b/gisce/compat.py
@@ -22,7 +22,7 @@ def is_interactive():
         get_ipython = getattr(builtins, 'get_ipython', None)
         if get_ipython is not None and get_ipython() is not None:
             return True
-    except Exception:
+    except (AttributeError, RuntimeError):
         pass
     return False
 

--- a/gisce/compat.py
+++ b/gisce/compat.py
@@ -31,3 +31,14 @@ def is_interactive():
 
 def prompt_password(label='Password: '):
     return getpass(label)
+
+
+def get_password(user, password):
+    """Return password for user; prompt if interactive and none provided, else raise."""
+    if not password:
+        if is_interactive():
+            return prompt_password()
+        raise ValueError(
+            "Password required for user '{}' but none provided.".format(user)
+        )
+    return password

--- a/gisce/compat.py
+++ b/gisce/compat.py
@@ -6,3 +6,7 @@ if PY2:
     from xmlrpclib import ServerProxy, SafeTransport
 else:
     from xmlrpc.client import ServerProxy, SafeTransport
+
+
+def prompt_password(label='Password: '):
+    return getpass(label)

--- a/gisce/compat.py
+++ b/gisce/compat.py
@@ -8,5 +8,24 @@ else:
     from xmlrpc.client import ServerProxy, SafeTransport
 
 
+def is_interactive():
+    """Detect if running in an interactive Python session (REPL, IPython, Jupyter, etc.)"""
+    if hasattr(sys, 'ps1'):
+        return True
+    try:
+        if sys.stdin.isatty():
+            return True
+    except AttributeError:
+        pass
+    try:
+        import builtins
+        get_ipython = getattr(builtins, 'get_ipython', None)
+        if get_ipython is not None and get_ipython() is not None:
+            return True
+    except Exception:
+        pass
+    return False
+
+
 def prompt_password(label='Password: '):
     return getpass(label)

--- a/gisce/compat.py
+++ b/gisce/compat.py
@@ -5,9 +5,11 @@ PY2 = sys.version_info < (3, 0, 0)
 if PY2:
     from xmlrpclib import ServerProxy, SafeTransport
     import httplib
+    import __builtin__ as builtins
 else:
     from xmlrpc.client import ServerProxy, SafeTransport
     import http.client as httplib
+    import builtins
 
 
 def is_interactive():
@@ -20,7 +22,6 @@ def is_interactive():
     except AttributeError:
         pass
     try:
-        import builtins
         get_ipython = getattr(builtins, 'get_ipython', None)
         if get_ipython is not None and get_ipython() is not None:
             return True

--- a/gisce/compat.py
+++ b/gisce/compat.py
@@ -1,4 +1,5 @@
 import sys
+from getpass import getpass
 PY2 = sys.version_info < (3, 0, 0)
 
 if PY2:

--- a/gisce/msgpack.py
+++ b/gisce/msgpack.py
@@ -59,6 +59,11 @@ class MsgPackClient(RequestsClient):
 
     def __init__(self, url, database, token=None, user=None, password=None,
                  content_type='json', verify=None):
+        # Prompt for password before calling parent init if needed
+        if user and not password and not token:
+            from .compat import getpass
+            password = getpass('Password: ')
+        
         super(MsgPackClient, self).__init__(url, token, user, password, verify)
         self.database = database
         assert content_type in ('json', 'msgpack')

--- a/gisce/msgpack.py
+++ b/gisce/msgpack.py
@@ -60,13 +60,8 @@ class MsgPackClient(RequestsClient):
     def __init__(self, url, database, token=None, user=None, password=None,
                  content_type='json', verify=None):
         if user and not password and not token:
-            from .compat import is_interactive, prompt_password
-            if is_interactive():
-                password = prompt_password()
-            else:
-                raise ValueError(
-                    "Password required for user '{}' but none provided.".format(user)
-                )
+            from .compat import get_password
+            password = get_password(user, password)
 
         super(MsgPackClient, self).__init__(url, token, user, password, verify)
         self.database = database

--- a/gisce/msgpack.py
+++ b/gisce/msgpack.py
@@ -58,15 +58,14 @@ class MsgPackClient(RequestsClient):
     model_class = MsgPackModel
 
     def __init__(self, url, database, token=None, user=None, password=None,
-                 content_type='json', verify=None, prompt_for_password=False):
+                 content_type='json', verify=None):
         if user and not password and not token:
-            if prompt_for_password:
-                from .compat import prompt_password
+            from .compat import is_interactive, prompt_password
+            if is_interactive():
                 password = prompt_password()
             else:
                 raise ValueError(
-                    "Password required for user '{}' but none provided. "
-                    "Use prompt_for_password=True for interactive prompting.".format(user)
+                    "Password required for user '{}' but none provided.".format(user)
                 )
 
         super(MsgPackClient, self).__init__(url, token, user, password, verify)

--- a/gisce/msgpack.py
+++ b/gisce/msgpack.py
@@ -58,12 +58,17 @@ class MsgPackClient(RequestsClient):
     model_class = MsgPackModel
 
     def __init__(self, url, database, token=None, user=None, password=None,
-                 content_type='json', verify=None):
-        # Prompt for password before calling parent init if needed
+                 content_type='json', verify=None, prompt_for_password=False):
         if user and not password and not token:
-            from .compat import getpass
-            password = getpass('Password: ')
-        
+            if prompt_for_password:
+                from .compat import prompt_password
+                password = prompt_password()
+            else:
+                raise ValueError(
+                    "Password required for user '{}' but none provided. "
+                    "Use prompt_for_password=True for interactive prompting.".format(user)
+                )
+
         super(MsgPackClient, self).__init__(url, token, user, password, verify)
         self.database = database
         assert content_type in ('json', 'msgpack')

--- a/gisce/xmlrpc.py
+++ b/gisce/xmlrpc.py
@@ -26,8 +26,7 @@ class XmlRpcClient(BaseClient):
             self._connection = http.client.HTTPSConnection(host, context=context)
             return self._connection
 
-    def __init__(self, url, database, token=None, user=None, password=None, verify=None,
-                 prompt_for_password=False):
+    def __init__(self, url, database, token=None, user=None, password=None, verify=None):
         super(XmlRpcClient, self).__init__()
         self.url = url + '/xmlrpc'
         if verify is not None and not verify:
@@ -45,13 +44,12 @@ class XmlRpcClient(BaseClient):
             self.password = token
         else:
             if user and not password:
-                if prompt_for_password:
-                    from .compat import prompt_password
+                from .compat import is_interactive, prompt_password
+                if is_interactive():
                     password = prompt_password()
                 else:
                     raise ValueError(
-                        "Password required for user '{}' but none provided. "
-                        "Use prompt_for_password=True for interactive prompting.".format(user)
+                        "Password required for user '{}' but none provided.".format(user)
                     )
             self.login(user, password)
         self.models = self.object.obj_list(

--- a/gisce/xmlrpc.py
+++ b/gisce/xmlrpc.py
@@ -26,7 +26,8 @@ class XmlRpcClient(BaseClient):
             self._connection = http.client.HTTPSConnection(host, context=context)
             return self._connection
 
-    def __init__(self, url, database, token=None, user=None, password=None, verify=None):
+    def __init__(self, url, database, token=None, user=None, password=None, verify=None,
+                 prompt_for_password=False):
         super(XmlRpcClient, self).__init__()
         self.url = url + '/xmlrpc'
         if verify is not None and not verify:
@@ -44,8 +45,14 @@ class XmlRpcClient(BaseClient):
             self.password = token
         else:
             if user and not password:
-                from .compat import getpass
-                password = getpass('Password: ')
+                if prompt_for_password:
+                    from .compat import prompt_password
+                    password = prompt_password()
+                else:
+                    raise ValueError(
+                        "Password required for user '{}' but none provided. "
+                        "Use prompt_for_password=True for interactive prompting.".format(user)
+                    )
             self.login(user, password)
         self.models = self.object.obj_list(
             self.database, self.uid, self.password

--- a/gisce/xmlrpc.py
+++ b/gisce/xmlrpc.py
@@ -53,13 +53,8 @@ class XmlRpcClient(BaseClient):
             self.password = token
         else:
             if user and not password:
-                from .compat import is_interactive, prompt_password
-                if is_interactive():
-                    password = prompt_password()
-                else:
-                    raise ValueError(
-                        "Password required for user '{}' but none provided.".format(user)
-                    )
+                from .compat import get_password
+                password = get_password(user, password)
             self.login(user, password)
         self.models = self.object.obj_list(
             self.database, self.uid, self.password

--- a/gisce/xmlrpc.py
+++ b/gisce/xmlrpc.py
@@ -43,6 +43,9 @@ class XmlRpcClient(BaseClient):
             self.uid = 'token'
             self.password = token
         else:
+            if user and not password:
+                from .compat import getpass
+                password = getpass('Password: ')
             self.login(user, password)
         self.models = self.object.obj_list(
             self.database, self.uid, self.password

--- a/tests/test_password_prompting.py
+++ b/tests/test_password_prompting.py
@@ -1,0 +1,327 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import sys
+import pytest
+import responses
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
+
+
+class TestIsInteractive(object):
+    """Tests for gisce.compat.is_interactive()"""
+
+    def test_returns_true_when_sys_ps1_present(self):
+        from gisce.compat import is_interactive
+        with patch.object(sys, 'ps1', '>>> ', create=True):
+            assert is_interactive() is True
+
+    def test_returns_true_when_stdin_is_tty(self):
+        from gisce.compat import is_interactive
+        mock_stdin = Mock()
+        mock_stdin.isatty.return_value = True
+        # Ensure ps1 is absent so only the isatty branch triggers
+        had_ps1 = hasattr(sys, 'ps1')
+        if had_ps1:
+            original_ps1 = sys.ps1
+            del sys.ps1
+        try:
+            with patch('sys.stdin', mock_stdin):
+                result = is_interactive()
+        finally:
+            if had_ps1:
+                sys.ps1 = original_ps1
+        assert result is True
+
+    def test_returns_false_when_stdin_not_tty_and_no_ps1(self):
+        from gisce.compat import is_interactive
+        mock_stdin = Mock()
+        mock_stdin.isatty.return_value = False
+        # Patch builtins so get_ipython is absent
+        import builtins
+        with patch.object(builtins, 'get_ipython', None, create=True), \
+             patch('sys.stdin', mock_stdin):
+            # Temporarily remove ps1 if present
+            had_ps1 = hasattr(sys, 'ps1')
+            if had_ps1:
+                original_ps1 = sys.ps1
+                del sys.ps1
+            try:
+                result = is_interactive()
+            finally:
+                if had_ps1:
+                    sys.ps1 = original_ps1
+            assert result is False
+
+    def test_returns_true_when_ipython_available_in_builtins(self):
+        from gisce.compat import is_interactive
+        import builtins
+        mock_get_ipython = Mock(return_value=Mock())
+        mock_stdin = Mock()
+        mock_stdin.isatty.return_value = False
+        with patch.object(builtins, 'get_ipython', mock_get_ipython, create=True), \
+             patch('sys.stdin', mock_stdin):
+            had_ps1 = hasattr(sys, 'ps1')
+            if had_ps1:
+                original_ps1 = sys.ps1
+                del sys.ps1
+            try:
+                result = is_interactive()
+            finally:
+                if had_ps1:
+                    sys.ps1 = original_ps1
+            assert result is True
+
+    def test_returns_false_when_ipython_returns_none(self):
+        from gisce.compat import is_interactive
+        import builtins
+        mock_get_ipython = Mock(return_value=None)
+        mock_stdin = Mock()
+        mock_stdin.isatty.return_value = False
+        with patch.object(builtins, 'get_ipython', mock_get_ipython, create=True), \
+             patch('sys.stdin', mock_stdin):
+            had_ps1 = hasattr(sys, 'ps1')
+            if had_ps1:
+                original_ps1 = sys.ps1
+                del sys.ps1
+            try:
+                result = is_interactive()
+            finally:
+                if had_ps1:
+                    sys.ps1 = original_ps1
+            assert result is False
+
+
+class TestGetPassword(object):
+    """Tests for gisce.compat.get_password()"""
+
+    def test_returns_provided_password_unchanged(self):
+        from gisce.compat import get_password
+        assert get_password('admin', 'secret') == 'secret'
+
+    def test_prompts_and_returns_when_interactive_and_no_password(self):
+        from gisce.compat import get_password
+        with patch('gisce.compat.is_interactive', return_value=True), \
+             patch('gisce.compat.prompt_password', return_value='prompted') as mock_prompt:
+            result = get_password('admin', None)
+        assert result == 'prompted'
+        mock_prompt.assert_called_once()
+
+    def test_raises_when_not_interactive_and_no_password(self):
+        from gisce.compat import get_password
+        with patch('gisce.compat.is_interactive', return_value=False):
+            with pytest.raises(ValueError) as exc_info:
+                get_password('admin', None)
+        assert 'admin' in str(exc_info.value)
+
+    def test_raises_when_not_interactive_and_empty_password(self):
+        from gisce.compat import get_password
+        with patch('gisce.compat.is_interactive', return_value=False):
+            with pytest.raises(ValueError):
+                get_password('admin', '')
+
+    def test_error_message_includes_username(self):
+        from gisce.compat import get_password
+        with patch('gisce.compat.is_interactive', return_value=False):
+            with pytest.raises(ValueError) as exc_info:
+                get_password('myuser', None)
+        assert 'myuser' in str(exc_info.value)
+
+    def test_does_not_prompt_when_password_provided(self):
+        from gisce.compat import get_password
+        with patch('gisce.compat.prompt_password') as mock_prompt:
+            get_password('admin', 'already_set')
+        mock_prompt.assert_not_called()
+
+
+class TestXmlRpcClientPasswordBehavior(object):
+    """Tests for password handling in XmlRpcClient.__init__"""
+
+    def _make_client(self, **kwargs):
+        from gisce.xmlrpc import XmlRpcClient
+        with patch('gisce.xmlrpc.ServerProxy') as mock_sp:
+            mock_common = Mock()
+            mock_common.login.return_value = 1
+            mock_object = Mock()
+            mock_object.obj_list.return_value = []
+            mock_report = Mock()
+
+            def factory(url, **kw):
+                if 'common' in url:
+                    return mock_common
+                elif 'report' in url:
+                    return mock_report
+                return mock_object
+
+            mock_sp.side_effect = factory
+            return XmlRpcClient(**kwargs)
+
+    def test_login_with_user_and_password(self):
+        client = self._make_client(
+            url='http://localhost:8069',
+            database='db',
+            user='admin',
+            password='secret'
+        )
+        assert client.uid == 1
+        assert client.password == 'secret'
+
+    def test_raises_when_no_password_non_interactive(self):
+        from gisce.xmlrpc import XmlRpcClient
+        with patch('gisce.compat.is_interactive', return_value=False):
+            with patch('gisce.xmlrpc.ServerProxy'):
+                with pytest.raises(ValueError) as exc_info:
+                    XmlRpcClient(
+                        url='http://localhost:8069',
+                        database='db',
+                        user='admin'
+                    )
+        assert 'admin' in str(exc_info.value)
+
+    def test_prompts_when_no_password_interactive(self):
+        from gisce.xmlrpc import XmlRpcClient
+        with patch('gisce.compat.is_interactive', return_value=True), \
+             patch('gisce.compat.prompt_password', return_value='prompted'), \
+             patch('gisce.xmlrpc.ServerProxy') as mock_sp:
+            mock_common = Mock()
+            mock_common.login.return_value = 42
+            mock_object = Mock()
+            mock_object.obj_list.return_value = []
+            mock_report = Mock()
+
+            def factory(url, **kw):
+                if 'common' in url:
+                    return mock_common
+                elif 'report' in url:
+                    return mock_report
+                return mock_object
+
+            mock_sp.side_effect = factory
+            client = XmlRpcClient(
+                url='http://localhost:8069',
+                database='db',
+                user='admin'
+            )
+        assert client.uid == 42
+        assert client.password == 'prompted'
+
+    def test_token_skips_password_prompt(self):
+        client = self._make_client(
+            url='http://localhost:8069',
+            database='db',
+            token='mytoken'
+        )
+        assert client.uid == 'token'
+        assert client.password == 'mytoken'
+
+
+class TestMsgPackClientPasswordBehavior(object):
+    """Tests for password handling in MsgPackClient.__init__"""
+
+    def _mock_responses(self):
+        responses.add(responses.POST, 'http://localhost:5000/common', json=1, status=200)
+        responses.add(responses.POST, 'http://localhost:5000/object', json=[], status=200)
+
+    @responses.activate
+    def test_login_with_user_and_password(self):
+        from gisce.msgpack import MsgPackClient
+        self._mock_responses()
+        client = MsgPackClient(
+            url='http://localhost:5000',
+            database='db',
+            user='admin',
+            password='secret',
+            content_type='json'
+        )
+        assert client.uid == 1
+        assert client.password == 'secret'
+
+    def test_raises_when_no_password_non_interactive(self):
+        from gisce.msgpack import MsgPackClient
+        with patch('gisce.compat.is_interactive', return_value=False):
+            with pytest.raises(ValueError) as exc_info:
+                MsgPackClient(
+                    url='http://localhost:5000',
+                    database='db',
+                    user='admin',
+                    content_type='json'
+                )
+        assert 'admin' in str(exc_info.value)
+
+    @responses.activate
+    def test_prompts_when_no_password_interactive(self):
+        from gisce.msgpack import MsgPackClient
+        self._mock_responses()
+        with patch('gisce.compat.is_interactive', return_value=True), \
+             patch('gisce.compat.prompt_password', return_value='prompted'):
+            client = MsgPackClient(
+                url='http://localhost:5000',
+                database='db',
+                user='admin',
+                content_type='json'
+            )
+        assert client.uid == 1
+        assert client.password == 'prompted'
+
+    @responses.activate
+    def test_token_skips_password_prompt(self):
+        from gisce.msgpack import MsgPackClient
+        responses.add(responses.POST, 'http://localhost:5000/object', json=[], status=200)
+        client = MsgPackClient(
+            url='http://localhost:5000',
+            database='db',
+            token='mytoken',
+            content_type='json'
+        )
+        assert client.uid == 'token'
+        assert client.password == 'mytoken'
+
+
+class TestRequestsClientPasswordBehavior(object):
+    """Tests for password handling in RequestsClient.__init__ (via RestApiClient)"""
+
+    @responses.activate
+    def test_login_with_user_and_password(self):
+        from gisce.restapi import RestApiClient
+        responses.add(
+            responses.POST, 'http://localhost:5000/ResModel/fields_get',
+            json={}, status=200
+        )
+        client = RestApiClient(
+            url='http://localhost:5000',
+            user='admin',
+            password='secret'
+        )
+        assert client.auth == ('admin', 'secret')
+
+    def test_raises_when_no_password_non_interactive(self):
+        from gisce.restapi import RestApiClient
+        with patch('gisce.compat.is_interactive', return_value=False):
+            with pytest.raises(ValueError) as exc_info:
+                RestApiClient(
+                    url='http://localhost:5000',
+                    user='admin'
+                )
+        assert 'admin' in str(exc_info.value)
+
+    @responses.activate
+    def test_prompts_when_no_password_interactive(self):
+        from gisce.restapi import RestApiClient
+        with patch('gisce.compat.is_interactive', return_value=True), \
+             patch('gisce.compat.prompt_password', return_value='prompted'):
+            client = RestApiClient(
+                url='http://localhost:5000',
+                user='admin'
+            )
+        assert client.auth == ('admin', 'prompted')
+
+    @responses.activate
+    def test_token_auth_skips_password_prompt(self):
+        from gisce.restapi import RestApiClient
+        client = RestApiClient(
+            url='http://localhost:5000',
+            token='mytoken'
+        )
+        assert 'Authorization' in client.headers
+        assert client.headers['Authorization'] == 'token mytoken'

--- a/tests/test_password_prompting.py
+++ b/tests/test_password_prompting.py
@@ -8,6 +8,11 @@ try:
 except ImportError:
     from mock import patch, Mock
 
+try:
+    import builtins
+except ImportError:
+    import __builtin__ as builtins
+
 
 class TestIsInteractive(object):
     """Tests for gisce.compat.is_interactive()"""
@@ -39,7 +44,6 @@ class TestIsInteractive(object):
         mock_stdin = Mock()
         mock_stdin.isatty.return_value = False
         # Patch builtins so get_ipython is absent
-        import builtins
         with patch.object(builtins, 'get_ipython', None, create=True), \
              patch('sys.stdin', mock_stdin):
             # Temporarily remove ps1 if present
@@ -56,7 +60,6 @@ class TestIsInteractive(object):
 
     def test_returns_true_when_ipython_available_in_builtins(self):
         from gisce.compat import is_interactive
-        import builtins
         mock_get_ipython = Mock(return_value=Mock())
         mock_stdin = Mock()
         mock_stdin.isatty.return_value = False
@@ -75,7 +78,6 @@ class TestIsInteractive(object):
 
     def test_returns_false_when_ipython_returns_none(self):
         from gisce.compat import is_interactive
-        import builtins
         mock_get_ipython = Mock(return_value=None)
         mock_stdin = Mock()
         mock_stdin.isatty.return_value = False


### PR DESCRIPTION
`is_interactive()` used an inline `import builtins` which fails on Python 2 (`ImportError: No module named builtins`). The same issue existed in the test file.

## Changes

- **`gisce/compat.py`**: Move `builtins` import to module level using the existing `PY2` guard — `import __builtin__ as builtins` on Python 2, `import builtins` on Python 3. Removes the inline import inside `is_interactive()`.
- **`tests/test_password_prompting.py`**: Replace three inline `import builtins` statements with a single top-level `try/except` compatible import.

```python
# compat.py — module level, consistent with existing PY2 pattern
if PY2:
    import __builtin__ as builtins
else:
    import builtins
```