### PR TITLE
Add X-Request-Id header

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,20 +7,33 @@ on:
     branches: [ main, master, develop ]
 
 jobs:
-  test:
+  test-python2:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['2.7', '3.11']
-      fail-fast: false
-
+    container: python:2.7-slim
+    
     steps:
     - uses: actions/checkout@v3
     
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+    
+    - name: Run tests
+      run: |
+        pytest tests/ -v --tb=short
+  
+  test-python3:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.11'
     
     - name: Install dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main, master, develop ]
+  pull_request:
+    branches: [ main, master, develop ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['2.7', '3.11']
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+    
+    - name: Run tests
+      run: |
+        pytest tests/ -v --tb=short

--- a/gisce/base.py
+++ b/gisce/base.py
@@ -80,9 +80,9 @@ class RequestsClient(requests.Session, BaseClient):
 
     def request(self, method, url, *args, **kwargs):
         url = '/'.join([self.url, url])
-        if 'headers' not in kwargs:
-            kwargs['headers'] = {}
-        kwargs['headers']['X-Request-Id'] = str(uuid.uuid4())
+        headers = kwargs.get('headers', {}).copy()
+        headers['X-Request-Id'] = str(uuid.uuid4())
+        kwargs['headers'] = headers
         return super(RequestsClient, self).request(method, url, *args, verify=self.verify, **kwargs)
 
 

--- a/gisce/base.py
+++ b/gisce/base.py
@@ -1,4 +1,5 @@
 import requests
+import uuid
 from . import __version__
 
 USER_AGENT = "PyGisceClient/Python"
@@ -79,6 +80,9 @@ class RequestsClient(requests.Session, BaseClient):
 
     def request(self, method, url, *args, **kwargs):
         url = '/'.join([self.url, url])
+        if 'headers' not in kwargs:
+            kwargs['headers'] = {}
+        kwargs['headers']['X-Request-Id'] = str(uuid.uuid4())
         return super(RequestsClient, self).request(method, url, *args, verify=self.verify, **kwargs)
 
 

--- a/gisce/compat.py
+++ b/gisce/compat.py
@@ -3,5 +3,7 @@ PY2 = sys.version_info < (3, 0, 0)
 
 if PY2:
     from xmlrpclib import ServerProxy, SafeTransport
+    import httplib
 else:
     from xmlrpc.client import ServerProxy, SafeTransport
+    import http.client as httplib

--- a/gisce/compat.py
+++ b/gisce/compat.py
@@ -3,7 +3,5 @@ PY2 = sys.version_info < (3, 0, 0)
 
 if PY2:
     from xmlrpclib import ServerProxy, SafeTransport
-    import httplib
 else:
     from xmlrpc.client import ServerProxy, SafeTransport
-    import http.client as httplib

--- a/gisce/xmlrpc.py
+++ b/gisce/xmlrpc.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
+import uuid
 from .base import BaseClient, PositionArgumentsModel, to_dot
-from .compat import ServerProxy, SafeTransport
+from .compat import ServerProxy, SafeTransport, httplib
 
 
 class XmlRpcModel(PositionArgumentsModel):
@@ -18,13 +19,21 @@ class XmlRpcModel(PositionArgumentsModel):
 class XmlRpcClient(BaseClient):
     model_class = XmlRpcModel
 
+    class BaseTransportWithRequestId(SafeTransport):
+        def send_content(self, connection, request_body):
+            connection.putheader("X-Request-Id", str(uuid.uuid4()))
+            SafeTransport.send_content(self, connection, request_body)
+
     class UnverifiedSSLTransport(SafeTransport):
         def make_connection(self, host):
             import ssl
-            import http.client
             context = ssl._create_unverified_context()
-            self._connection = http.client.HTTPSConnection(host, context=context)
+            self._connection = httplib.HTTPSConnection(host, context=context)
             return self._connection
+
+        def send_content(self, connection, request_body):
+            connection.putheader("X-Request-Id", str(uuid.uuid4()))
+            SafeTransport.send_content(self, connection, request_body)
 
     def __init__(self, url, database, token=None, user=None, password=None, verify=None):
         super(XmlRpcClient, self).__init__()
@@ -32,7 +41,7 @@ class XmlRpcClient(BaseClient):
         if verify is not None and not verify:
             self.server_proxy_kwargs = {'transport': self.UnverifiedSSLTransport()}
         else:
-            self.server_proxy_kwargs = {}
+            self.server_proxy_kwargs = {'transport': self.BaseTransportWithRequestId()}
         self.common = ServerProxy(self.url + '/common', allow_none=True, **self.server_proxy_kwargs)
         self.object = ServerProxy(self.url + '/object', allow_none=True, **self.server_proxy_kwargs)
         self.report_service = ServerProxy(self.url + '/report', allow_none=True, **self.server_proxy_kwargs)

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import uuid
+import pytest
+import responses
+from gisce.restapi import RestApiClient
+from gisce.msgpack import MsgPackClient
+
+
+class TestRequestIdHeader(object):
+    """Test that X-Request-Id header is added to all requests"""
+
+    @responses.activate
+    def test_restapi_client_adds_request_id(self):
+        """Test RestApiClient adds X-Request-Id header"""
+        # Mock fields_get call
+        responses.add(
+            responses.POST,
+            'http://localhost:5000/RestApiModel/fields_get',
+            json={'res': {}},
+            status=200
+        )
+        
+        # Mock the API endpoint
+        responses.add(
+            responses.POST,
+            'http://localhost:5000/RestApiModel/test_method',
+            json={'res': 'success'},
+            status=200
+        )
+        
+        # Create client and make a request
+        client = RestApiClient(
+            url='http://localhost:5000',
+            user='test',
+            password='test'
+        )
+        model = client.model('rest.api.model')
+        model.test_method()
+        
+        # Verify X-Request-Id header was sent
+        assert len(responses.calls) == 2
+        # Check the actual test_method call (second request)
+        request_headers = responses.calls[1].request.headers
+        assert 'X-Request-Id' in request_headers
+        # Verify it's a valid UUID4
+        request_id = request_headers['X-Request-Id']
+        try:
+            uuid_obj = uuid.UUID(request_id, version=4)
+            assert str(uuid_obj) == request_id
+        except (ValueError, AttributeError):
+            pytest.fail("X-Request-Id is not a valid UUID4")
+
+    @responses.activate
+    def test_msgpack_client_adds_request_id_json(self):
+        """Test MsgPackClient adds X-Request-Id header with JSON content type"""
+        # Mock the login endpoint
+        responses.add(
+            responses.POST,
+            'http://localhost:5000/common',
+            json=123,  # uid
+            status=200
+        )
+        
+        # Mock the obj_list endpoint
+        responses.add(
+            responses.POST,
+            'http://localhost:5000/object',
+            json=['model1', 'model2'],
+            status=200
+        )
+        
+        # Create client
+        client = MsgPackClient(
+            url='http://localhost:5000',
+            database='test_db',
+            user='test',
+            password='test',
+            content_type='json'
+        )
+        
+        # Verify X-Request-Id header was sent in all requests
+        assert len(responses.calls) == 2
+        for call in responses.calls:
+            request_headers = call.request.headers
+            assert 'X-Request-Id' in request_headers
+            # Verify it's a valid UUID4
+            request_id = request_headers['X-Request-Id']
+            try:
+                uuid_obj = uuid.UUID(request_id, version=4)
+                assert str(uuid_obj) == request_id
+            except (ValueError, AttributeError):
+                pytest.fail("X-Request-Id is not a valid UUID4")
+
+    @responses.activate
+    def test_msgpack_client_model_call_adds_request_id(self):
+        """Test MsgPackClient model calls add X-Request-Id header"""
+        # Mock the login endpoint
+        responses.add(
+            responses.POST,
+            'http://localhost:5000/common',
+            json=123,  # uid
+            status=200
+        )
+        
+        # Mock the obj_list endpoint
+        responses.add(
+            responses.POST,
+            'http://localhost:5000/object',
+            json=['test.model'],
+            status=200
+        )
+        
+        # Mock fields_get call
+        responses.add(
+            responses.POST,
+            'http://localhost:5000/object',
+            json={},
+            status=200
+        )
+        
+        # Mock a model method call
+        responses.add(
+            responses.POST,
+            'http://localhost:5000/object',
+            json={'success': True},
+            status=200
+        )
+        
+        # Create client and make a model call
+        client = MsgPackClient(
+            url='http://localhost:5000',
+            database='test_db',
+            user='test',
+            password='test',
+            content_type='json'
+        )
+        model = client.model('test.model')
+        model.search([])
+        
+        # Verify X-Request-Id header was sent in all requests (login, obj_list, fields_get, search)
+        assert len(responses.calls) == 4
+        for call in responses.calls:
+            request_headers = call.request.headers
+            assert 'X-Request-Id' in request_headers
+
+    @responses.activate
+    def test_each_request_gets_unique_request_id(self):
+        """Test that each request gets a different X-Request-Id"""
+        # Mock fields_get call
+        responses.add(
+            responses.POST,
+            'http://localhost:5000/TestModel/fields_get',
+            json={'res': {}},
+            status=200
+        )
+        
+        # Mock multiple endpoints
+        for _ in range(3):
+            responses.add(
+                responses.POST,
+                'http://localhost:5000/TestModel/test_method',
+                json={'res': 'success'},
+                status=200
+            )
+        
+        # Create client
+        client = RestApiClient(
+            url='http://localhost:5000',
+            user='test',
+            password='test'
+        )
+        model = client.model('test.model')
+        
+        # Make multiple requests
+        model.test_method()
+        model.test_method()
+        model.test_method()
+        
+        # Collect all request IDs (skip first call which is fields_get)
+        request_ids = []
+        for call in responses.calls[1:]:  # Skip fields_get call
+            request_id = call.request.headers['X-Request-Id']
+            request_ids.append(request_id)
+        
+        # Verify all request IDs are unique
+        assert len(request_ids) == 3
+        assert len(set(request_ids)) == 3, "Request IDs should be unique"

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -71,7 +71,7 @@ class TestRequestIdHeader(object):
         )
         
         # Create client
-        client = MsgPackClient(
+        MsgPackClient(
             url='http://localhost:5000',
             database='test_db',
             user='test',

--- a/tests/test_xmlrpc_request_id.py
+++ b/tests/test_xmlrpc_request_id.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import uuid
+import pytest
+try:
+    from unittest.mock import Mock, patch, MagicMock
+except ImportError:
+    from mock import Mock, patch, MagicMock
+
+from gisce.xmlrpc import XmlRpcClient
+
+
+class TestXmlRpcRequestId(object):
+    """Test that X-Request-Id header is added to XmlRpc requests"""
+
+    def test_xmlrpc_transport_adds_request_id(self):
+        """Test that XmlRpcClient transport adds X-Request-Id header"""
+        # Mock the ServerProxy and its methods
+        with patch('gisce.xmlrpc.ServerProxy') as mock_server_proxy:
+            # Setup mocks for each ServerProxy instance
+            mock_common = Mock()
+            mock_common.login.return_value = 1
+            
+            mock_object = Mock()
+            mock_object.obj_list.return_value = ['test.model']
+            
+            mock_report = Mock()
+            
+            # Configure ServerProxy to return different mocks based on URL
+            def server_proxy_factory(url, **kwargs):
+                if 'common' in url:
+                    return mock_common
+                elif 'report' in url:
+                    return mock_report
+                else:
+                    return mock_object
+            
+            mock_server_proxy.side_effect = server_proxy_factory
+            
+            # Create client
+            client = XmlRpcClient(
+                url='http://localhost:8069',
+                database='test_db',
+                user='admin',
+                password='admin'
+            )
+            
+            # Verify that transport was created
+            assert mock_server_proxy.call_count == 3
+            
+            # Check that BaseTransportWithRequestId was used (verify=None case)
+            transport_arg = mock_server_proxy.call_args_list[0][1].get('transport')
+            assert transport_arg is not None
+            assert isinstance(transport_arg, XmlRpcClient.BaseTransportWithRequestId)
+
+    def test_xmlrpc_unverified_transport_adds_request_id(self):
+        """Test that XmlRpcClient unverified transport adds X-Request-Id header"""
+        with patch('gisce.xmlrpc.ServerProxy') as mock_server_proxy:
+            # Setup mocks
+            mock_common = Mock()
+            mock_common.login.return_value = 1
+            
+            mock_object = Mock()
+            mock_object.obj_list.return_value = ['test.model']
+            
+            mock_report = Mock()
+            
+            def server_proxy_factory(url, **kwargs):
+                if 'common' in url:
+                    return mock_common
+                elif 'report' in url:
+                    return mock_report
+                else:
+                    return mock_object
+            
+            mock_server_proxy.side_effect = server_proxy_factory
+            
+            # Create client with verify=False
+            client = XmlRpcClient(
+                url='http://localhost:8069',
+                database='test_db',
+                user='admin',
+                password='admin',
+                verify=False
+            )
+            
+            # Verify that UnverifiedSSLTransport was used
+            transport_arg = mock_server_proxy.call_args_list[0][1].get('transport')
+            assert transport_arg is not None
+            assert isinstance(transport_arg, XmlRpcClient.UnverifiedSSLTransport)
+
+    def test_transport_send_content_adds_header(self):
+        """Test that transport's send_content method adds X-Request-Id"""
+        # Create a transport instance
+        transport = XmlRpcClient.BaseTransportWithRequestId()
+        
+        # Mock connection
+        mock_connection = Mock()
+        
+        # Call send_content
+        transport.send_content(mock_connection, b'<test>data</test>')
+        
+        # Verify putheader was called with X-Request-Id
+        assert mock_connection.putheader.called
+        call_args = mock_connection.putheader.call_args_list
+        
+        # Find the X-Request-Id header call
+        x_request_id_call = None
+        for call in call_args:
+            if call[0][0] == 'X-Request-Id':
+                x_request_id_call = call
+                break
+        
+        assert x_request_id_call is not None, "X-Request-Id header was not added"
+        
+        # Verify it's a valid UUID4
+        request_id = x_request_id_call[0][1]
+        try:
+            uuid_obj = uuid.UUID(request_id, version=4)
+            assert str(uuid_obj) == request_id
+        except (ValueError, AttributeError):
+            pytest.fail("X-Request-Id is not a valid UUID4")
+
+    def test_unverified_transport_send_content_adds_header(self):
+        """Test that UnverifiedSSLTransport's send_content adds X-Request-Id"""
+        # Create a transport instance
+        transport = XmlRpcClient.UnverifiedSSLTransport()
+        
+        # Mock connection
+        mock_connection = Mock()
+        
+        # Call send_content
+        transport.send_content(mock_connection, b'<test>data</test>')
+        
+        # Verify putheader was called with X-Request-Id
+        assert mock_connection.putheader.called
+        call_args = mock_connection.putheader.call_args_list
+        
+        # Find the X-Request-Id header call
+        x_request_id_call = None
+        for call in call_args:
+            if call[0][0] == 'X-Request-Id':
+                x_request_id_call = call
+                break
+        
+        assert x_request_id_call is not None, "X-Request-Id header was not added"
+        
+        # Verify it's a valid UUID4
+        request_id = x_request_id_call[0][1]
+        try:
+            uuid_obj = uuid.UUID(request_id, version=4)
+            assert str(uuid_obj) == request_id
+        except (ValueError, AttributeError):
+            pytest.fail("X-Request-Id is not a valid UUID4")

--- a/tests/test_xmlrpc_request_id.py
+++ b/tests/test_xmlrpc_request_id.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import
 import uuid
 import pytest
 try:
-    from unittest.mock import Mock, patch, MagicMock
+    from unittest.mock import Mock, patch
 except ImportError:
-    from mock import Mock, patch, MagicMock
+    from mock import Mock, patch
 
 from gisce.xmlrpc import XmlRpcClient
 

--- a/tests/test_xmlrpc_request_id.py
+++ b/tests/test_xmlrpc_request_id.py
@@ -38,7 +38,7 @@ class TestXmlRpcRequestId(object):
             mock_server_proxy.side_effect = server_proxy_factory
             
             # Create client
-            client = XmlRpcClient(
+            XmlRpcClient(
                 url='http://localhost:8069',
                 database='test_db',
                 user='admin',


### PR DESCRIPTION
This pull request introduces support for automatically adding a unique `X-Request-Id` header to every outgoing HTTP and XML-RPC request made by the client libraries. This improves traceability and debugging by ensuring each request can be uniquely identified. The implementation covers REST, MsgPack, and XML-RPC transports, and includes comprehensive tests to verify correct behavior across all supported protocols and Python versions. Additionally, a GitHub Actions workflow is added to run tests on multiple Python versions.

**Request ID Header Implementation:**

* Added logic to inject a unique `X-Request-Id` header (UUID4) into every outgoing HTTP request in the `RequestsClient` by updating the `request` method in `gisce/base.py`.
* Introduced custom XML-RPC transports (`BaseTransportWithRequestId` and `UnverifiedSSLTransport`) in `gisce/xmlrpc.py` to add the `X-Request-Id` header to all XML-RPC calls, including support for both verified and unverified SSL connections.
* Updated imports and compatibility handling for HTTP libraries to support both Python 2 and 3 in `gisce/compat.py`, `gisce/base.py`, and `gisce/xmlrpc.py`. [[1]](diffhunk://#diff-70f4ce29967b61282d18bb9de081da30d95fd1019c60daf7515065ae4f4cc4c3R2) [[2]](diffhunk://#diff-6ff22a4f94ea58d36ceaea5b283b18299312c5484ac6182a9fd1f875de6e66b8R6-R9) [[3]](diffhunk://#diff-ec57c3cd16deab46f79c335e7c8fd6011567b394289921629c9958563842b3f4R2-R4)

**Testing Enhancements:**

* Added comprehensive tests in `tests/test_request_id.py` and `tests/test_xmlrpc_request_id.py` to verify that the `X-Request-Id` header is present, unique, and valid for REST, MsgPack, and XML-RPC clients. These tests use mocking and the `responses` library to ensure correctness without requiring real network calls. [[1]](diffhunk://#diff-9031dccdb075bcfb42b1cb08f19f1a6d563107dd845e308fa6ebfa44bee59e63R1-R188) [[2]](diffhunk://#diff-947e715ddd6479e30c18de35511206766fa0e7202be7ebe8fecce17310202b82R1-R154)

**Continuous Integration:**

* Introduced a new GitHub Actions workflow (`.github/workflows/tests.yml`) to automatically run tests on pushes and pull requests for multiple Python versions (2.7 and 3.11), ensuring compatibility and reliability.


## Related

- https://github.com/gisce/webclient/issues/2884