### PR TITLE
feat: build standalone CLI binary on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,36 +3,53 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+'
-      - 'v[0-9]+\.[0-9]+\.[0-9]+'
+      - 'v[0-9]*.[0-9]*.[0-9]*-rc[0-9]*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
+
+permissions:
+  contents: write
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Get tag
-        id: tag
-        uses: dawidd6/action-get-tag@v1
-        with:
-          strip_v: false
-      - name: Run setup
+      - name: Build source distribution
         run: |
           python setup.py sdist
-      - name: Creating a realease/pre-release
+      - name: Install binary build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r requirements-build.txt
+      - name: Build standalone CLI binary
+        run: |
+          pyinstaller \
+            --onefile \
+            --name pygisceclient-linux-x86_64 \
+            --distpath release-assets \
+            --paths . \
+            --collect-submodules gisce \
+            packaging/pygisceclient_pyinstaller.py
+          ./release-assets/pygisceclient-linux-x86_64 --help
+          cd release-assets
+          sha256sum pygisceclient-linux-x86_64 > pygisceclient-linux-x86_64.sha256
+      - name: Create release/pre-release
         id: create_release
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{steps.tag.outputs.tag}}
+          tag_name: ${{ github.ref_name }}
           draft: false
           prerelease: ${{ contains(github.ref, '-rc') }}
           generate_release_notes: true
+          files: |
+            release-assets/pygisceclient-linux-x86_64
+            release-assets/pygisceclient-linux-x86_64.sha256
       - name: Publish a Python distribution to PyPI
         if: ${{ contains(github.ref, '-rc') }} == false
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+release-assets/
 develop-eggs/
 dist/
 downloads/

--- a/README.md
+++ b/README.md
@@ -133,3 +133,17 @@ pygisceclient \
 ```
 
 The result is printed as JSON to standard output.
+
+## Standalone release binary
+
+GitHub releases include a Linux x86_64 standalone CLI binary named
+`pygisceclient-linux-x86_64`, plus its `.sha256` checksum. The binary is built
+with PyInstaller when a version tag such as `v0.10.1` or `v0.10.1-rc1` is
+pushed.
+
+The release binary can be used without installing the Python package:
+
+```bash
+chmod +x pygisceclient-linux-x86_64
+./pygisceclient-linux-x86_64 --help
+```

--- a/packaging/pygisceclient_pyinstaller.py
+++ b/packaging/pygisceclient_pyinstaller.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import
+
+from gisce.cli import main
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,2 @@
+pyinstaller==6.11.1
+pyinstaller-hooks-contrib==2026.5


### PR DESCRIPTION
## Resum

- Afegeix build de binari standalone Linux x86_64 del CLI amb PyInstaller al workflow de release.
- Adjunta el binari i el `.sha256` a GitHub Releases quan es publica un tag `vX.Y.Z` o `vX.Y.Z-rcN`.
- Corregeix els patrons de tags del workflow perquè siguin globs vàlids de GitHub Actions i separa els assets de release de `dist/` per no interferir amb PyPI.
- Documenta al README com executar el binari descarregat.

## Validació

- `python setup.py sdist`
- `python -m pytest tests/ -v --tb=short` -> 49 passed
- `pyinstaller --onefile --name pygisceclient-linux-x86_64 --distpath release-assets --paths . --collect-submodules gisce packaging/pygisceclient_pyinstaller.py`
- `./release-assets/pygisceclient-linux-x86_64 --help`
- `sha256sum pygisceclient-linux-x86_64`

## Notes

El binari és standalone via PyInstaller one-file per Linux x86_64. No és un binari ELF totalment estàtic en sentit estricte de glibc, però sí executable sense instal·lar el paquet Python.

Closes #28
