### PR TITLE
fix: install release build dependency

### DIFF
--- a/releaserc.toml
+++ b/releaserc.toml
@@ -1,7 +1,7 @@
 [semantic_release]
 tag_format = "v{version}"
 version_variables = ["setup.py:version"]
-build_command = "python setup.py sdist"
+build_command = "python -m pip install setuptools && python setup.py sdist"
 commit_message = "chore(release): {version}"
 commit_parser = "conventional"
 major_on_zero = false


### PR DESCRIPTION
## Summary

- Install `setuptools` inside the `python-semantic-release` build command before running `setup.py sdist`.
- Keep the release path on legacy `setup.py sdist`; no `pyproject.toml`, no wheel requirement, no packaging-surface expansion.

## Why

The first post-merge Release run from #31 failed in the semantic-release action container because its `python` environment did not include `setuptools`:

```text
ModuleNotFoundError: No module named 'setuptools'
```

## Validation

- `/home/openclaw/.local/share/py-gisce-client/venv/bin/pytest tests/ -v --tb=short` -> 49 passed
- `/home/openclaw/.local/share/py-gisce-client/venv/bin/python -m pip install setuptools && /home/openclaw/.local/share/py-gisce-client/venv/bin/python setup.py sdist` -> OK

Refs #30
