### PR TITLE
feat: expose MsgPack services in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ password = 'admin'
 database = 'test'
 c = Client(url, database=database, user=user, password=password)
 users_obj = c.model('res.users')
+
+features = c.common.check_for_features(['my_feature'])
+databases = c.db.list()
+report_id = c.report('account.invoice', [1])
 ```
 
 ## Using XML-RPC API interface
@@ -85,7 +89,8 @@ After installing the package, a `pygisceclient` command is available. This is us
 ```
 usage: pygisceclient [-h] --url URL --database DATABASE
                      (--token TOKEN | --user USER) [--password PASSWORD]
-                     --model MODEL --method METHOD
+                     (--model MODEL | --service SERVICE) --method METHOD
+                     [--service-auth {auto,raw,authenticated}]
                      [--args ARGS] [--kwargs KWARGS] [--no-verify]
 ```
 
@@ -99,7 +104,9 @@ usage: pygisceclient [-h] --url URL --database DATABASE
 | `--user USER` | `-u` | Username |
 | `--password PASS` | `-p` | Password (required with `--user`) |
 | `--model MODEL` | `-m` | Model name (e.g. `res.users`) |
-| `--method METHOD` | | Method name (e.g. `search`) |
+| `--service SERVICE` | `-s` | Service name (e.g. `common`, `db`, `report`) |
+| `--method METHOD` | | Method name (e.g. `search`, `check_for_features`) |
+| `--service-auth MODE` | | Auth mode for service calls: `auto`, `raw`, or `authenticated` |
 | `--args JSON` | | Positional arguments as a JSON array (default `[]`) |
 | `--kwargs JSON` | | Keyword arguments as a JSON object (default `{}`) |
 | `--no-verify` | | Disable SSL certificate verification |
@@ -133,6 +140,23 @@ pygisceclient \
 ```
 
 The result is printed as JSON to standard output.
+
+Call a MsgPack service directly:
+
+```bash
+pygisceclient \
+  --url https+msgpack://erp.example.com \
+  --database mydb \
+  --token myapitoken \
+  --service common \
+  --method check_for_features \
+  --args '[["feature_a", "feature_b"]]'
+```
+
+Service calls use positional JSON arguments. By default, `common`, `db` and
+`wc` are called raw because several of their methods do not receive `database`,
+`uid` and `password`; other services are called authenticated. Use
+`--service-auth raw` or `--service-auth authenticated` to force one mode.
 
 ## Standalone release binary
 

--- a/gisce/cli.py
+++ b/gisce/cli.py
@@ -6,6 +6,9 @@ import sys
 from . import connect
 
 
+SERVICE_AUTH_CHOICES = ('auto', 'raw', 'authenticated')
+
+
 def build_parser():
     parser = argparse.ArgumentParser(
         prog='pygisceclient',
@@ -39,15 +42,28 @@ def build_parser():
         '--password', '-p',
         help='Password for authentication (required when --user is used)',
     )
-    parser.add_argument(
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument(
         '--model', '-m',
-        required=True,
         help='Model name, e.g. res.users',
+    )
+    target.add_argument(
+        '--service', '-s',
+        help='Service name, e.g. common, db, report',
     )
     parser.add_argument(
         '--method',
         required=True,
-        help='Method name to call on the model, e.g. search',
+        help='Method name to call on the model or service, e.g. search',
+    )
+    parser.add_argument(
+        '--service-auth',
+        choices=SERVICE_AUTH_CHOICES,
+        default='auto',
+        help=(
+            'Authentication mode for --service calls. auto uses raw for '
+            'common/db/wc and authenticated for the other services.'
+        ),
     )
     parser.add_argument(
         '--args',
@@ -91,6 +107,9 @@ def main(argv=None):
     if not isinstance(call_kwargs, dict):
         parser.error('--kwargs must be a JSON object')
 
+    if args.service and call_kwargs:
+        parser.error('--kwargs is only supported with --model')
+
     connect_kwargs = {
         'verify': not args.no_verify,
     }
@@ -115,11 +134,24 @@ def main(argv=None):
         sys.exit(1)
 
     try:
-        model = client.model(args.model)
-        method = getattr(model, args.method)
+        target_name = args.model or args.service
+        if args.model:
+            target = client.model(args.model)
+        else:
+            if not hasattr(client, 'service'):
+                raise Exception(
+                    'Service calls are not supported by this protocol'
+                )
+            service_auth = {
+                'auto': None,
+                'raw': False,
+                'authenticated': True,
+            }[args.service_auth]
+            target = client.service(args.service, authenticated=service_auth)
+        method = getattr(target, args.method)
         result = method(*call_args, **call_kwargs)
     except Exception as exc:
-        print('Error calling {}.{}: {}'.format(args.model, args.method, exc), file=sys.stderr)
+        print('Error calling {}.{}: {}'.format(target_name, args.method, exc), file=sys.stderr)
         sys.exit(1)
 
     print(json.dumps(result, indent=2, default=str))

--- a/gisce/msgpack.py
+++ b/gisce/msgpack.py
@@ -8,9 +8,10 @@ except ImportError:
 
 
 class MsgPackProtocol(object):
-    def __init__(self, api, endpoint):
+    def __init__(self, api, endpoint, authenticated=True):
         self.api = api
         self.endpoint = endpoint
+        self.authenticated = authenticated
 
     def __getattr__(self, item):
         def wrapper(*args, **kwargs):
@@ -18,12 +19,14 @@ class MsgPackProtocol(object):
         return wrapper
 
     def _call(self, method, *args, **kwargs):
-        payload = list((
-            method,
-            self.api.database,
-            self.api.uid,
-            self.api.password,
-        ) + args)
+        payload = [method]
+        if self.authenticated:
+            payload.extend([
+                self.api.database,
+                self.api.uid,
+                self.api.password,
+            ])
+        payload.extend(args)
         if self.api.content_type == 'application/json':
             response = self.api.post(self.endpoint, json=payload)
             result = response.json()
@@ -56,6 +59,7 @@ class MsgPackModel(PositionArgumentsModel):
 
 class MsgPackClient(RequestsClient):
     model_class = MsgPackModel
+    raw_services = ('common', 'db', 'wc')
 
     def __init__(self, url, database, token=None, user=None, password=None,
                  content_type='json', verify=None):
@@ -78,8 +82,11 @@ class MsgPackClient(RequestsClient):
             self.password = token
         else:
             self.login(user, password)
-        self.report_service = MsgPackProtocol(self, 'report')
-        self.models = MsgPackProtocol(self, 'object').obj_list()
+        self.common = self.service('common', authenticated=False)
+        self.db = self.service('db', authenticated=False)
+        self.report_service = self.service('report')
+        self.object_service = self.service('object')
+        self.models = self.object_service.obj_list()
 
     def login(self, user, password):
         result = self.post('common', json=['login', self.database, user, password])
@@ -88,6 +95,11 @@ class MsgPackClient(RequestsClient):
             self.password = password
         else:
             raise ValueError('Error with user/password')
+
+    def service(self, name, authenticated=None):
+        if authenticated is None:
+            authenticated = name not in self.raw_services
+        return MsgPackProtocol(self, name, authenticated=authenticated)
 
     def report(self, object, ids, datas=None, context=None):
         return self.report_service.report(object, ids, datas, context)

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -20,8 +20,9 @@ pygisceclient \
   --url <PROTOCOL_URL> \
   --database <DB> \
   --user <USER> --password <PASS> \
-  --model <MODEL> \
+  (--model <MODEL> | --service <SERVICE>) \
   --method <METHOD> \
+  [--service-auth auto|raw|authenticated] \
   --args '<JSON_ARRAY>' \
   --kwargs '<JSON_OBJECT>'
 ```
@@ -167,7 +168,49 @@ pygisceclient ... --model account.invoice --method invoice_open \
 
 ---
 
-## 4. Domain Syntax (Search Filters)
+## 4. MsgPack Services
+
+When using `https+msgpack://` or `http+msgpack://`, the CLI can call MsgPack
+services directly with `--service`.
+
+```bash
+pygisceclient \
+  --url https+msgpack://erp.example.com \
+  --database mydb \
+  --token "$ERP_TOKEN" \
+  --service common \
+  --method check_for_features \
+  --args '[["feature_a", "feature_b"]]'
+```
+
+Service calls use positional JSON arguments only; `--kwargs` is reserved for
+model calls. The default `--service-auth auto` mode calls `common`, `db` and
+`wc` raw, because many of their methods do not receive `database`, `uid` and
+`password`. Other services are called authenticated.
+
+Force the mode only when the ERP service expects the opposite convention:
+
+```bash
+pygisceclient ... --service report --service-auth authenticated \
+  --method report --args '["account.invoice", [1], {}, {}]'
+
+pygisceclient ... --service common --service-auth raw \
+  --method check_for_features --args '[["webclient_feature"]]'
+```
+
+In Python, use `MsgPackClient.service(name, authenticated=None)` for the same
+behavior. `None` means auto mode; pass `False` for raw or `True` for
+authenticated:
+
+```python
+features = client.common.check_for_features(['webclient_feature'])
+databases = client.db.list()
+report_id = client.service('report').report('account.invoice', [1], {}, {})
+```
+
+---
+
+## 5. Domain Syntax (Search Filters)
 
 Domains are lists of condition tuples following Polish (prefix) notation.
 
@@ -213,7 +256,7 @@ Complex:
 
 ---
 
-## 5. Field Types
+## 6. Field Types
 
 ### Simple fields
 
@@ -260,7 +303,7 @@ Use special tuple commands in `write`/`create` vals:
 
 ---
 
-## 6. Common Workflow Patterns
+## 7. Common Workflow Patterns
 
 ### Discover a model's schema
 
@@ -311,7 +354,7 @@ pygisceclient ... --model ir.model.fields --method read \
 
 ---
 
-## 7. Core Base Models
+## 8. Core Base Models
 
 These models are always available:
 
@@ -340,7 +383,7 @@ These models are always available:
 
 ---
 
-## 8. Best Practices
+## 9. Best Practices
 
 1. **Always discover the schema first** — call `fields_get` on a model before reading or writing.
 2. **Paginate large results** — use `offset` and `limit` in `search`. Process in batches of 1000.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,10 +34,39 @@ class TestBuildParser(object):
         assert args.user == 'admin'
         assert args.password == 'secret'
         assert args.model == 'res.users'
+        assert args.service is None
         assert args.method == 'search'
+        assert args.service_auth == 'auto'
         assert args.args == '[]'
         assert args.kwargs == '{}'
         assert not args.no_verify
+
+    def test_parses_service_target(self):
+        parser = build_parser()
+        args = parser.parse_args([
+            '--url', 'https+msgpack://erp.example.com',
+            '--database', 'mydb',
+            '--token', 'mytoken',
+            '--service', 'common',
+            '--method', 'check_for_features',
+            '--args', '[["feature_a"]]',
+        ])
+        assert args.model is None
+        assert args.service == 'common'
+        assert args.method == 'check_for_features'
+        assert args.service_auth == 'auto'
+
+    def test_model_and_service_are_mutually_exclusive(self):
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args([
+                '--url', 'https+msgpack://erp.example.com',
+                '--database', 'mydb',
+                '--token', 'mytoken',
+                '--model', 'res.users',
+                '--service', 'common',
+                '--method', 'check_for_features',
+            ])
 
     def test_parses_token_auth(self):
         parser = build_parser()
@@ -230,6 +259,74 @@ class TestMain(object):
 
         captured = capsys.readouterr()
         assert json.loads(captured.out) == mock_result
+
+    def test_successful_service_call_uses_auto_auth(self, capsys):
+        mock_result = {'feature_a': {'name': 'feature_a'}}
+        mock_service = MagicMock()
+        mock_service.check_for_features.return_value = mock_result
+        mock_client = MagicMock()
+        mock_client.service.return_value = mock_service
+
+        with patch('gisce.cli.connect', return_value=mock_client) as mock_connect:
+            main([
+                '--url', 'https+msgpack://erp.example.com',
+                '--database', 'mydb',
+                '--token', 'mytoken',
+                '--service', 'common',
+                '--method', 'check_for_features',
+                '--args', '[["feature_a"]]',
+            ])
+
+        mock_connect.assert_called_once_with(
+            'https+msgpack://erp.example.com',
+            'mydb',
+            verify=True,
+            token='mytoken',
+        )
+        mock_client.service.assert_called_once_with(
+            'common',
+            authenticated=None,
+        )
+        mock_service.check_for_features.assert_called_once_with(['feature_a'])
+
+        captured = capsys.readouterr()
+        assert json.loads(captured.out) == mock_result
+
+    def test_service_auth_can_be_forced_from_cli(self, capsys):
+        mock_service = MagicMock()
+        mock_service.report.return_value = 'report-id'
+        mock_client = MagicMock()
+        mock_client.service.return_value = mock_service
+
+        with patch('gisce.cli.connect', return_value=mock_client):
+            main([
+                '--url', 'https+msgpack://erp.example.com',
+                '--database', 'mydb',
+                '--token', 'mytoken',
+                '--service', 'report',
+                '--service-auth', 'authenticated',
+                '--method', 'report',
+                '--args', '["report.name", [1], {}, {}]',
+            ])
+
+        mock_client.service.assert_called_once_with(
+            'report',
+            authenticated=True,
+        )
+        captured = capsys.readouterr()
+        assert json.loads(captured.out) == 'report-id'
+
+    def test_service_call_rejects_kwargs(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main([
+                '--url', 'https+msgpack://erp.example.com',
+                '--database', 'mydb',
+                '--token', 'mytoken',
+                '--service', 'common',
+                '--method', 'check_for_features',
+                '--kwargs', '{"context": {}}',
+            ])
+        assert exc_info.value.code != 0
 
     def test_connect_error_exits(self, capsys):
         with patch('gisce.cli.connect', side_effect=Exception('connection refused')):

--- a/tests/test_msgpack_services.py
+++ b/tests/test_msgpack_services.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import responses
+from gisce.msgpack import MsgPackClient
+
+
+class TestMsgPackServices(object):
+    def _mock_client_bootstrap(self):
+        responses.add(
+            responses.POST,
+            'http://localhost:5000/common',
+            json=1,
+            status=200,
+        )
+        responses.add(
+            responses.POST,
+            'http://localhost:5000/object',
+            json=[],
+            status=200,
+        )
+
+    @responses.activate
+    def test_common_service_uses_raw_payload_by_default(self):
+        self._mock_client_bootstrap()
+        responses.add(
+            responses.POST,
+            'http://localhost:5000/common',
+            json={'feature_a': {'name': 'feature_a'}},
+            status=200,
+        )
+
+        client = MsgPackClient(
+            url='http://localhost:5000',
+            database='db',
+            user='admin',
+            password='secret',
+            content_type='json',
+        )
+        result = client.common.check_for_features(['feature_a'])
+
+        assert result == {'feature_a': {'name': 'feature_a'}}
+        assert responses.calls[2].request.body == (
+            b'["check_for_features", ["feature_a"]]'
+        )
+
+    @responses.activate
+    def test_report_service_uses_authenticated_payload_by_default(self):
+        self._mock_client_bootstrap()
+        responses.add(
+            responses.POST,
+            'http://localhost:5000/report',
+            json='report-id',
+            status=200,
+        )
+
+        client = MsgPackClient(
+            url='http://localhost:5000',
+            database='db',
+            user='admin',
+            password='secret',
+            content_type='json',
+        )
+        result = client.service('report').report('report.name', [1], {}, {})
+
+        assert result == 'report-id'
+        assert responses.calls[2].request.body == (
+            b'["report", "db", 1, "secret", "report.name", [1], {}, {}]'
+        )
+
+    @responses.activate
+    def test_service_authentication_can_be_forced(self):
+        self._mock_client_bootstrap()
+        responses.add(
+            responses.POST,
+            'http://localhost:5000/common',
+            json=True,
+            status=200,
+        )
+
+        client = MsgPackClient(
+            url='http://localhost:5000',
+            database='db',
+            user='admin',
+            password='secret',
+            content_type='json',
+        )
+        result = client.service('common', authenticated=True).ir_del(12)
+
+        assert result is True
+        assert responses.calls[2].request.body == (
+            b'["ir_del", "db", 1, "secret", 12]'
+        )


### PR DESCRIPTION
## Resumen
- Expone servicios MsgPack mediante `MsgPackClient.service(...)` y accesos directos raw para `common`, `db` y `wc`.
- Mantiene `object`/`report` como servicios autenticados y conserva los helpers `report()` / `report_get()`.
- Añade `pygisceclient --service ... --method ...` con `--service-auth auto|raw|authenticated`.
- Documenta el uso para `common.check_for_features` en README y en la skill `gisce-erp`.

## Pruebas
- `~/.local/share/py-gisce-client/venv/bin/pytest -q` -> 57 passed
- `~/.pyenv/versions/erp2/bin/python -m pytest -q tests/test_cli.py tests/test_msgpack_services.py tests/test_request_id.py` -> 30 passed
- `~/.local/share/py-gisce-client/venv/bin/pytest -q tests/test_cli.py tests/test_msgpack_services.py` -> 26 passed

## Nota
- La suite completa en Python 2 sigue fallando en `tests/test_password_prompting.py::TestIsInteractive::test_returns_true_when_ipython_available_in_builtins`; está reproducido también en `main`, no es regresión de esta rama.
