### PR TITLE
fix: keep release bump commits on protected main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,14 +47,9 @@ jobs:
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
           config_file: releaserc.toml
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # The release job runs on protected main. Keep version stamping local
-          # for the build artifacts, then tag the triggering commit without
-          # pushing a release commit to main.
-          commit: "false"
-          tag: "true"
-          push: "true"
-          vcs_release: "true"
+          # Semantic release must push the version bump commit and the matching
+          # tag. On protected main, configure GH_PAT with the required bypass.
+          github_token: ${{ secrets.GH_PAT || github.token }}
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           config_file: releaserc.toml
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # The release job runs on protected main. Keep version stamping local
+          # for the build artifacts, but do not push a release commit to main.
+          commit: "false"
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,12 @@ jobs:
           config_file: releaserc.toml
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # The release job runs on protected main. Keep version stamping local
-          # for the build artifacts, but do not push a release commit to main.
+          # for the build artifacts, then tag the triggering commit without
+          # pushing a release commit to main.
           commit: "false"
+          tag: "true"
+          push: "true"
+          vcs_release: "true"
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
 

--- a/README.md
+++ b/README.md
@@ -150,11 +150,12 @@ chmod +x pygisceclient-linux-x86_64
 ## Automated releases
 
 Releases are generated from conventional commits merged into `main`.
-`python-semantic-release` updates `setup.py`, creates the release commit and tag,
-builds the source distribution with `python setup.py sdist`, and publishes the
-GitHub release assets. The GitHub release upload includes both the `dist/*`
-source distribution and the `release-assets/*` standalone CLI binary plus
-checksum.
+`python-semantic-release` stamps the next version in the workflow checkout,
+builds the source distribution with `python setup.py sdist`, tags the triggering
+commit, and publishes the GitHub release assets. It does not push a release
+commit to `main`, so branch protection still requires code changes to go through
+pull requests. The GitHub release upload includes both the `dist/*` source
+distribution and the `release-assets/*` standalone CLI binary plus checksum.
 
 PyPI publishing uses `PYPI_TOKEN` when configured, falling back to the
 organization-level `PYPI_MASTER_TOKEN`.

--- a/README.md
+++ b/README.md
@@ -150,15 +150,19 @@ chmod +x pygisceclient-linux-x86_64
 ## Automated releases
 
 Releases are generated from conventional commits merged into `main`.
-`python-semantic-release` stamps the next version in the workflow checkout,
-builds the source distribution with `python setup.py sdist`, tags the triggering
-commit, and publishes the GitHub release assets. It does not push a release
-commit to `main`, so branch protection still requires code changes to go through
-pull requests. The GitHub release upload includes both the `dist/*` source
-distribution and the `release-assets/*` standalone CLI binary plus checksum.
+`python-semantic-release` updates `setup.py`, creates the release commit and
+tag, builds the source distribution with `python setup.py sdist`, and publishes
+the GitHub release assets. The version tag points to the release commit that
+contains the `setup.py` version bump.
 
-PyPI publishing uses `PYPI_TOKEN` when configured, falling back to the
-organization-level `PYPI_MASTER_TOKEN`.
+The release workflow pushes the release commit and tag from GitHub Actions. If
+`main` is protected, the repository must configure `GH_PAT` with the required
+permission or branch-protection bypass for this release push. Without that
+bypass, the workflow will fail when pushing the version bump commit to `main`.
+The GitHub release upload includes both the `dist/*` source distribution and the
+`release-assets/*` standalone CLI binary plus checksum. PyPI publishing uses
+`PYPI_TOKEN` when configured, falling back to the organization-level
+`PYPI_MASTER_TOKEN`.
 
 The release flow is:
 
@@ -166,14 +170,11 @@ The release flow is:
 2. The release workflow runs on that merge commit.
 3. `python-semantic-release` calculates the next version from conventional
    commits and existing tags.
-4. The workflow checkout gets the stamped `setup.py` version only for the local
-   build.
-5. The source distribution in `dist/*` and the standalone binary in
-   `release-assets/*` are built from that stamped checkout.
-6. The workflow pushes the version tag, creates the GitHub Release, uploads the
-   Python distribution and binary assets to that release, and uploads `dist/*`
-   to PyPI when a PyPI token is configured.
-
-There is no `chore(release): ...` commit on `main`. The released project version
-is represented by the version tag and by the published artifacts, not by a
-version-bump commit in the repository history.
+4. The workflow updates `setup.py`, creates the release commit, and pushes that
+   commit to `main`.
+5. The workflow creates and pushes the version tag on that release commit.
+6. The source distribution in `dist/*` and the standalone binary in
+   `release-assets/*` are built from the release commit checkout.
+7. The workflow creates the GitHub Release, uploads the Python distribution and
+   binary assets to that release, and uploads `dist/*` to PyPI when a PyPI token
+   is configured.

--- a/README.md
+++ b/README.md
@@ -159,3 +159,21 @@ distribution and the `release-assets/*` standalone CLI binary plus checksum.
 
 PyPI publishing uses `PYPI_TOKEN` when configured, falling back to the
 organization-level `PYPI_MASTER_TOKEN`.
+
+The release flow is:
+
+1. A normal pull request is merged into `main`.
+2. The release workflow runs on that merge commit.
+3. `python-semantic-release` calculates the next version from conventional
+   commits and existing tags.
+4. The workflow checkout gets the stamped `setup.py` version only for the local
+   build.
+5. The source distribution in `dist/*` and the standalone binary in
+   `release-assets/*` are built from that stamped checkout.
+6. The workflow pushes the version tag, creates the GitHub Release, uploads the
+   Python distribution and binary assets to that release, and uploads `dist/*`
+   to PyPI when a PyPI token is configured.
+
+There is no `chore(release): ...` commit on `main`. The released project version
+is represented by the version tag and by the published artifacts, not by a
+version-bump commit in the repository history.


### PR DESCRIPTION
## Summary
- Keep the semantic-release version bump commit on `main` so `setup.py` advances in repository history.
- Keep the version tag attached to that release commit, matching the existing `v0.10.0` pattern and other GISCE release workflows.
- Use `GH_PAT` when configured, falling back to `github.token`, and document that protected `main` needs a controlled release bypass for this push.

## Context
Issue #34 failed because `python-semantic-release` tried to push the release bump commit directly to protected `main` using the default GitHub Actions token.

The previous attempt in this PR avoided that by disabling release commits, but that changed the release model: the tag would point to the merge commit, while the `setup.py` bump would only exist inside the runner and published artifacts. That is not the desired model here.

The intended model is now explicit: semantic-release creates the release commit, pushes it to `main`, tags that commit, creates the GitHub Release, uploads the binary/Python distribution assets, and publishes to PyPI when a PyPI token is configured. Operationally, the repo must configure `GH_PAT` with permission or branch-protection bypass for the release push.

## Validation
- `python3` YAML parse of `.github/workflows/release.yml` -> OK
- `/home/openclaw/.local/share/py-gisce-client/venv/bin/python -m pytest tests/ -v --tb=short` -> 49 passed

Refs #34
