### PR TITLE
fix: allow XML-RPC over HTTP

### DIFF
--- a/gisce/compat.py
+++ b/gisce/compat.py
@@ -3,11 +3,11 @@ from getpass import getpass
 PY2 = sys.version_info < (3, 0, 0)
 
 if PY2:
-    from xmlrpclib import ServerProxy, SafeTransport
+    from xmlrpclib import ServerProxy, Transport, SafeTransport
     import httplib
     import __builtin__ as builtins
 else:
-    from xmlrpc.client import ServerProxy, SafeTransport
+    from xmlrpc.client import ServerProxy, Transport, SafeTransport
     import http.client as httplib
     import builtins
 

--- a/gisce/xmlrpc.py
+++ b/gisce/xmlrpc.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import uuid
 from .base import BaseClient, PositionArgumentsModel, to_dot
-from .compat import ServerProxy, SafeTransport, httplib
+from .compat import ServerProxy, Transport, SafeTransport, httplib
 
 
 class XmlRpcModel(PositionArgumentsModel):
@@ -18,6 +18,11 @@ class XmlRpcModel(PositionArgumentsModel):
 
 class XmlRpcClient(BaseClient):
     model_class = XmlRpcModel
+
+    class TransportWithRequestId(Transport):
+        def send_content(self, connection, request_body):
+            connection.putheader("X-Request-Id", str(uuid.uuid4()))
+            Transport.send_content(self, connection, request_body)
 
     class BaseTransportWithRequestId(SafeTransport):
         def send_content(self, connection, request_body):
@@ -38,10 +43,13 @@ class XmlRpcClient(BaseClient):
     def __init__(self, url, database, token=None, user=None, password=None, verify=None):
         super(XmlRpcClient, self).__init__()
         self.url = url + '/xmlrpc'
-        if verify is not None and not verify:
+        is_https = url.lower().startswith('https://')
+        if is_https and verify is not None and not verify:
             self.server_proxy_kwargs = {'transport': self.UnverifiedSSLTransport()}
-        else:
+        elif is_https:
             self.server_proxy_kwargs = {'transport': self.BaseTransportWithRequestId()}
+        else:
+            self.server_proxy_kwargs = {'transport': self.TransportWithRequestId()}
         self.common = ServerProxy(self.url + '/common', allow_none=True, **self.server_proxy_kwargs)
         self.object = ServerProxy(self.url + '/object', allow_none=True, **self.server_proxy_kwargs)
         self.report_service = ServerProxy(self.url + '/report', allow_none=True, **self.server_proxy_kwargs)

--- a/tests/test_xmlrpc_request_id.py
+++ b/tests/test_xmlrpc_request_id.py
@@ -48,10 +48,10 @@ class TestXmlRpcRequestId(object):
             # Verify that transport was created
             assert mock_server_proxy.call_count == 3
             
-            # Check that BaseTransportWithRequestId was used (verify=None case)
+            # Check that HTTP transport was used for HTTP URLs
             transport_arg = mock_server_proxy.call_args_list[0][1].get('transport')
             assert transport_arg is not None
-            assert isinstance(transport_arg, XmlRpcClient.BaseTransportWithRequestId)
+            assert isinstance(transport_arg, XmlRpcClient.TransportWithRequestId)
 
     def test_xmlrpc_unverified_transport_adds_request_id(self):
         """Test that XmlRpcClient unverified transport adds X-Request-Id header"""
@@ -77,7 +77,7 @@ class TestXmlRpcRequestId(object):
             
             # Create client with verify=False
             client = XmlRpcClient(
-                url='http://localhost:8069',
+                url='https://localhost:8069',
                 database='test_db',
                 user='admin',
                 password='admin',
@@ -88,6 +88,39 @@ class TestXmlRpcRequestId(object):
             transport_arg = mock_server_proxy.call_args_list[0][1].get('transport')
             assert transport_arg is not None
             assert isinstance(transport_arg, XmlRpcClient.UnverifiedSSLTransport)
+
+    def test_xmlrpc_http_uses_http_transport_when_verify_false(self):
+        """HTTP URLs must not use an HTTPS-only transport."""
+        with patch('gisce.xmlrpc.ServerProxy') as mock_server_proxy:
+            mock_common = Mock()
+            mock_common.login.return_value = 1
+
+            mock_object = Mock()
+            mock_object.obj_list.return_value = ['test.model']
+
+            mock_report = Mock()
+
+            def server_proxy_factory(url, **kwargs):
+                if 'common' in url:
+                    return mock_common
+                elif 'report' in url:
+                    return mock_report
+                else:
+                    return mock_object
+
+            mock_server_proxy.side_effect = server_proxy_factory
+
+            XmlRpcClient(
+                url='http://localhost:8069',
+                database='test_db',
+                user='admin',
+                password='admin',
+                verify=False
+            )
+
+            transport_arg = mock_server_proxy.call_args_list[0][1].get('transport')
+            assert transport_arg is not None
+            assert isinstance(transport_arg, XmlRpcClient.TransportWithRequestId)
 
     def test_transport_send_content_adds_header(self):
         """Test that transport's send_content method adds X-Request-Id"""


### PR DESCRIPTION
## Summary
- Use a plain XML-RPC HTTP transport for `http://` XML-RPC URLs instead of an HTTPS-only `SafeTransport`.
- Keep HTTPS XML-RPC on `SafeTransport`, and keep `--no-verify` limited to HTTPS via the unverified SSL transport.
- Add regression coverage for `http://` + `verify=False`.

Fixes #36
TASK-92097

## Tests
- `/home/openclaw/.local/share/py-gisce-client/venv/bin/pytest -q`
- `pyenv activate erp2 && python -m pytest tests/test_xmlrpc_request_id.py -q`

## Notes
- Full Python 2 suite currently has an unrelated failure in `tests/test_password_prompting.py::TestIsInteractive::test_returns_true_when_ipython_available_in_builtins` (`is_interactive()` returns False under that test setup). The XML-RPC focused tests pass on Python 2.